### PR TITLE
feat: allow API base URL override

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,4 +1,4 @@
-const API_BASE = '/api';
+const API_BASE = window.API_BASE || '/api';
 let currentUser = null;
 let authToken = localStorage.getItem('authToken');
 

--- a/public/index.html
+++ b/public/index.html
@@ -302,7 +302,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        window.API_BASE = 'https://your-app.onrender.com/api';
+        window.API_BASE = 'https://volhelper.onrender.com/api';
     </script>
     <script src="app.js"></script>
 </body>

--- a/public/index.html
+++ b/public/index.html
@@ -301,6 +301,9 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        window.API_BASE = 'https://your-app.onrender.com/api';
+    </script>
     <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow client API base URL override via `window.API_BASE`
- set `window.API_BASE` to Render API endpoint in `index.html`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b717f567848331abca14e1cebe0630